### PR TITLE
F5 in VS actually runs KJ now

### DIFF
--- a/Jedi/Jedi/JediUI.csproj
+++ b/Jedi/Jedi/JediUI.csproj
@@ -35,7 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Kennedy.ManagedHooks">
+    <Reference Include="Kennedy.ManagedHooks, Version=1.2.0.10, Culture=neutral">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Libs\Kennedy.ManagedHooks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
@@ -92,6 +93,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>copy "$(SolutionDir)..\libs\*.*" "$(TargetDir)" /Y</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Just had to add a pre-build event to copy the files from the libs folder. I know it's a bit overkill, given that the UI project already contains a reference to the Kennedy assembly, but this was easy and, honestly, a bit more flexible. 